### PR TITLE
Add flexible parameter for hub location

### DIFF
--- a/MATLAB/example/example_analysis.m
+++ b/MATLAB/example/example_analysis.m
@@ -63,7 +63,9 @@ number_surrogate = 10; % Number of surrogate wPLI to create
 p_value = 0.05; % the p value to make our test on
 threshold = 0.10; % This is the threshold at which we binarize the graph
 step_size = 10;
-result_hl = na_hub_location(recording, frequency_band, window_size, step_size, number_surrogate, p_value, threshold);
+a_degree = 1.0;
+a_bc = 0.0;
+result_hl = na_hub_location(recording, frequency_band, window_size, step_size, number_surrogate, p_value, threshold, a_degree, a_bc);
 
 % Permutation Entropy (PE)
 frequency_band = [7 13]; % This is in Hz

--- a/MATLAB/example/test_hub_location.m
+++ b/MATLAB/example/test_hub_location.m
@@ -13,7 +13,9 @@ frequency_band = [7 13]; % This is in Hz
 window_size = 20; % This is in seconds and will be how we chunk the whole dataset
 number_surrogate = 20; % Number of surrogate wPLI to create
 p_value = 0.05; % the p value to make our test on
-step_size = 0.1;
+step_size = 10;
+a_degree = 1.0;
+a_bc = 1.0;
 result_wpli = na_wpli(recording, frequency_band, window_size, step_size, number_surrogate, p_value);
 
 % Calculating Hub Location on the each window of wpli
@@ -32,7 +34,7 @@ max_location = zeros(1,num_window);
 for i = 1:num_window   
     % binarized the wpli matrix
     b_wpli = binarize_matrix(threshold_matrix(squeeze(wpli(i,:,:)), t_level_wpli));
-    [hub_location, weights] = binary_hub_location(b_wpli, channels_location);
+    [hub_location, weights] = binary_hub_location(b_wpli, channels_location, a_degree, a_bc);
     hub_map(i,:) = weights;
 end
 

--- a/MATLAB/features/graph_theory/binary_hub_location.m
+++ b/MATLAB/features/graph_theory/binary_hub_location.m
@@ -1,9 +1,13 @@
-function [hub_location, weights] = binary_hub_location(b_wpli, location)
+function [hub_location, weights] = binary_hub_location(b_wpli, location, a_degree, a_bc)
 %BETWEENESS_HUB_LOCATION select a channel which is the highest hub based on
 %betweeness centrality and degree
 % input:
 % b_wpli: binary matrix
 % location: 3d channels location
+% a_degree: weight to put on the degree for the definition of hub
+% a_bc: weight to put on the betweeness centrality for the definition of
+% hub
+%
 % output:
 % hub_location: This is a number between 0 and 1, where 0 is fully
 % posterior and 1 is fully anterior
@@ -13,12 +17,10 @@ function [hub_location, weights] = binary_hub_location(b_wpli, location)
     %% 1.Calculate the degree for each electrode.
     degrees = degrees_und(b_wpli);
     norm_degree = (degrees - mean(degrees)) / std(degrees);
-    a_degree = 1.0;
     
     %% 2. Calculate the betweeness centrality for each electrode.
     bc = betweenness_bin(b_wpli);
     norm_bc = (bc - mean(bc)) / std(bc);
-    a_bc = 1.0;
     
     
     %% 3. Combine the two Weightsmetric (here we assume equal weight on both the degree and the betweeness centrality)

--- a/MATLAB/src/na_hub_location.m
+++ b/MATLAB/src/na_hub_location.m
@@ -1,4 +1,4 @@
-function [result] = na_hub_location(recording, frequency_band, window_size, step_size, number_surrogate, p_value ,threshold)
+function [result] = na_hub_location(recording, frequency_band, window_size, step_size, number_surrogate, p_value ,threshold, a_degree, a_bc)
 %NA_HUB_LOCATION will calculate hub locations
 %(as defined by betweeness-centrality and degree) for the whole recording 
 %of EEG data and store it inside a result data structure. 
@@ -22,6 +22,9 @@ function [result] = na_hub_location(recording, frequency_band, window_size, step
 %   p_value: p value at which to say that a connection is significant
 %   threshold: from 0 to 1 it's the amount of top connection we want to
 %   keep in the wPLI->binary_wpli.
+%   a_degree: weight to put on the degree for the definition of hub
+%   a_bc: weight to put on the betweeness centrality for the definition of
+%   hub
 %
 %   output:
 %   result: a datastructure containing all the parameters information,
@@ -48,6 +51,8 @@ function [result] = na_hub_location(recording, frequency_band, window_size, step
     result.parameters.p_value = p_value;
     result.parameters.threshold = threshold;
     result.parameters.step_size = step_size;
+    result.parameters.a_degree = a_degree;
+    result.parameters.a_bc = a_bc;
     
     %% Filtering the data
     print_message(strcat("Filtering Data from ",string(frequency_band(1)), "Hz to ", string(frequency_band(2)), "Hz."),configuration.is_verbose);
@@ -73,7 +78,7 @@ function [result] = na_hub_location(recording, frequency_band, window_size, step
        b_wpli = binarize_matrix(threshold_matrix(segment_wpli, threshold));
        
        % Calculating hub data for the segment
-       [hub_index, weights] = binary_hub_location(b_wpli, location);
+       [hub_index, weights] = binary_hub_location(b_wpli, location, a_degree, a_bc);
        
        % Saving the hub data for this segment
        result.data.hub_index(i) = hub_index;

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ NA comes bundled with a few features that can be used out of the box.
 
 ### Hub Location
 A hub is a node in the brain with a lot of incoming connection, but a few outputing connection.
-We can use the degree to approximate this, however using betweeness centrality help a lot the analysis. 
+We can use the degree to approximate this, however using betweeness centrality help a lot the analysis. **The hub location has now two parameter to control how much of the degree and the betweeness centrality we want to take into consideration.**
 Below you will see the hub location definition we've build using the [Brain Connectivity Toolbox](https://sites.google.com/site/bctnet/).
 
 Concretely this is how we can use the `na_hub_location.m` functino:
@@ -27,17 +27,19 @@ Concretely this is how we can use the `na_hub_location.m` functino:
    p_value = 0.05; 
    threshold = 0.10;
    step_size = 10;
-   result_hl = na_hub_location(recording, frequency_band, window_size, step_size, number_surrogate, p_value, threshold);
+   a_degree = 1.0;
+   a_bc = 1.0;
+   result_hl = na_hub_location(recording, frequency_band, window_size, step_size, number_surrogate, p_value, threshold, a_degree, a_bc);
 
 ```
 For more detailed help type `help na_hub_location` at the MATLAB command prompt.
 
 The definition of a hub we are using is the following:
-`hub = Max of (1.0*norm_betweenes_centrality + 1.0*norm_degree)`
+`hub = Max of (a_bc*norm_betweenes_centrality + a_degree*norm_degree)`
 
 This is given by the following code:
 ```matlab
-function [hub_location] = betweeness_hub_location(b_wpli, location)
+function [hub_location] = betweeness_hub_location(b_wpli, location, a_degree, a_bc)
 %BETWEENESS_HUB_LOCATION select a channel which is the highest hub based on
 %betweeness centrality and degree
 % b_wpli: binary matrix
@@ -46,13 +48,11 @@ function [hub_location] = betweeness_hub_location(b_wpli, location)
     %% 1.Calculate the degree for each electrode.
     degrees = degrees_und(b_wpli);
     norm_degree = (degrees - mean(degrees)) / std(degrees);
-    a_degree = 1.0;
     
     
     %% 2. Calculate the betweeness centrality for each electrode.
     bc = betweenness_bin(b_wpli);
     norm_bc = (bc - mean(bc)) / std(bc);
-    a_bc = 1.0;
     
     
     %% 3. Combine the two metric (here we assume equal weight on both the degree and the betweeness centrality)


### PR DESCRIPTION
We want to be able to use either the betweeness centrality or the degree or both in order to define a hub. I've added these as parameters instead of having them hardcoded at 1.0 for each of theme. More information can be found in the README.md